### PR TITLE
fix: built-in debug funcs not showing

### DIFF
--- a/types/environment.d.luau
+++ b/types/environment.d.luau
@@ -229,7 +229,7 @@ type debug = {
     getproto: ((func_or_level: AnyFunction | number, index: number, activated: true) -> { AnyFunction }) &
               ((func_or_level: AnyFunction | number, index: number, activated: false?) -> AnyFunction),
 }
-declare debug: debug
+declare debug: typeof(debug) & debug
 
 declare class DrawingObject
     Visible: boolean


### PR DESCRIPTION
@Stefanuk12